### PR TITLE
Create hfhub.py util for HugginfFace Hub model storage

### DIFF
--- a/darts/utils/hfhub.py
+++ b/darts/utils/hfhub.py
@@ -1,0 +1,51 @@
+import pandas as pd
+from dotenv import load_dotenv
+import os
+import tempfile
+from typing import Optional
+from darts.models.forecasting.forecasting_model import ForecastingModel
+from huggingface_hub import snapshot_download, upload_folder, create_repo
+
+
+class HFHub:
+    """
+    HuggingFace Hub integration using official HF API.
+    https://huggingface.co/docs/huggingface_hub/v0.20.3/en/guides/integrations
+    """
+
+    def __init__(self, api_key: Optional[str] = None):
+        if api_key is None:
+            # load from .env file or OS vars if available
+            load_dotenv(override=True)
+            api_key = os.getenv("HF_TOKEN")
+            assert (
+                api_key is not None
+            ), "Could not find HF_TOKEN in OS environment. Cannot interact with HF Hub."
+        self.HF_TOKEN = api_key
+
+    def upload_model(
+        self,
+        model: ForecastingModel = None,
+        repo_id: str = None,
+        private: Optional[bool] = True,
+    ):
+        # Create repo if not existing yet and get the associated repo_id
+        create_repo(repo_id=repo_id, repo_type="model", private=private, exist_ok=True)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            # print("created temporary directory for model", tmpdirname)
+            model.save(path=f"{tmpdirname}/{model.model_name}")
+            upload_folder(repo_id=repo_id, folder_path=tmpdirname, token=self.HF_TOKEN)
+
+    def download_model(
+        self,
+        repo_id: str = None,
+        model_name: str = None,
+        model_class: object = None,
+    ) -> ForecastingModel:
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            snapshot_download(
+                repo_id=repo_id, local_dir=tmpdirname, token=self.HF_TOKEN
+            )
+            model = model_class.load(path=f"{tmpdirname}/{model_name}")
+            return model


### PR DESCRIPTION
HFHub is a convenient cloud service for storing models, datasets and demo spaces. It would make it easier for timeseries ML engineers to build and deploy demos of Darts models and timeseries datasets if they can be saved and loaded from hfhub.

Example usage (see cell 56):
https://github.com/ivelin/canswim/blob/pypackage/model_sandbox.ipynb

<!-- Please mention an issue this pull request addresses. -->
Fixes #.

### Summary

<!-- Provide a general description of the code changes in your pull
request. If your pull request is not ready to merge, please create
a draft and ask for comments. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, code samples, or others. -->

<!--Thank you for contributing to darts! -->
